### PR TITLE
Adds secure variable to inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   dest: 
     description: 'Destination file path on remote FTP'
     required: true
+  secure: 
+    description: '(boolean | "implicit") Explicit FTPS over TLS, default: false. Use "implicit" if you need support for legacy implicit FTPS.'
+    required: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   secure: 
     description: '(boolean | "implicit") Explicit FTPS over TLS, default: false. Use "implicit" if you need support for legacy implicit FTPS.'
     required: false
+  verbose:
+    description: 'Default is false. If true verbose logging is used to debug the ftp connection and upload.'
+    required: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ async function main() {
         
         const client = new ftp.Client()
         client.ftp.verbose = verbose
+        client..ftp.log = core.debug;
 
         await client.access({
             host: host,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ async function main() {
         
         const client = new ftp.Client()
         client.ftp.verbose = verbose
-        client..ftp.log = core.debug;
+        client.ftp.log = core.debug;
 
         await client.access({
             host: host,


### PR DESCRIPTION
The input was missing on the yml, causing github warn about this:

Unexpected input(s) 'secure', valid inputs are ['user', 'password', 'host', 'port', 'src', 'dest']