### PR TITLE
Support self signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ This action performs a single file transfer using FTP.
 
 **Optional** (boolean | "implicit") Explicit FTPS over TLS, default: false. Use "implicit" if you need support for legacy implicit FTPS.
 
+
+### `rejectUnauthorized`
+
+**Optional** Whether to allow unauthorized servers when using `secure` mode. default:true. Set to false when using self-signed certificates
+
 ### `verbose`
 
 **Optional** Default is false. If true verbose logging is used to debug the ftp connection and upload.

--- a/action.yml
+++ b/action.yml
@@ -18,15 +18,19 @@ inputs:
     description: 'FTP Hostname'
     required: false
     default: '21'
-  src: 
+  src:
     description: 'Path to file to upload'
     required: true
-  dest: 
+  dest:
     description: 'Destination file path on remote FTP'
     required: true
-  secure: 
+  secure:
     description: '(boolean | "implicit") Explicit FTPS over TLS, default: false. Use "implicit" if you need support for legacy implicit FTPS.'
     required: false
+  rejectUnauthorized:
+    description: 'Default is true. If false will allow unauthorized servers when using secure mode (such as servers using self-signed certificates)'
+    required: false
+    default: 'true'
   verbose:
     description: 'Default is false. If true verbose logging is used to debug the ftp connection and upload.'
     required: false

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ async function main() {
           secure = secure === 'true'
         }
 
+        const rejectUnauthorized = core.getInput('rejectUnauthorized') === 'true'
+
         const src = core.getInput('src')
         const dest = core.getInput('dest') || './'
         const verbose = core.getInput('verbose') || false
@@ -25,7 +27,8 @@ async function main() {
             port: port,
             user: user,
             password: password,
-            secure: secure
+            secure: secure,
+            secureOptions: { rejectUnauthorized: rejectUnauthorized },
         })
 
         await client.uploadFrom(src, dest)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core')
-const ftp = require("basic-ftp") 
+const ftp = require("basic-ftp")
 
 async function main() {
     try {
@@ -7,11 +7,15 @@ async function main() {
         const password = core.getInput('password')
         const host = core.getInput('host')
         const port = core.getInput('port') || '21'
-        const secure = core.getInput('secure') || false
+        let secure = core.getInput('secure')
+        if (secure !== 'implicit') {
+          secure = secure === 'true'
+        }
+
         const src = core.getInput('src')
         const dest = core.getInput('dest') || './'
         const verbose = core.getInput('verbose') || false
-        
+
         const client = new ftp.Client()
         client.ftp.verbose = verbose
         client.ftp.log = core.debug;
@@ -27,7 +31,7 @@ async function main() {
         await client.uploadFrom(src, dest)
 
         client.close()
-        
+
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Addresses #3.

There are two changes in this PR:

1. `secure` was not being treated as a boolean, and was therefore being ignored. From testing, I would get a `550 SSL/TLS required on the control channel` because our FTP server required TLS.
2. Support for talking to unauthorized servers. Our server uses a self signed certificate. When running this script locally an error would be thrown as part of the TLS connection. The change here allows this issue to be ignored.

For the second point I was hoping there was something more explicit about allowing self-signed certs but I couldn't see anything related to it